### PR TITLE
fix: distribute rounding dust to the last claimant in forfeited puzzles

### DIFF
--- a/src/GuessGame.sol
+++ b/src/GuessGame.sol
@@ -61,8 +61,14 @@ contract GuessGame is IGuessGame, Initializable, UUPSUpgradeable, OwnableUpgrade
     /// @notice Time allowed for creator to respond before forfeit becomes possible
     uint256 public constant RESPONSE_TIMEOUT = 1 days;
 
+    /// @notice Tracks total bounty amount claimed per puzzle (for forfeit distribution)
+    mapping(uint256 => uint256) public bountyClaimedTotal;
+
+    /// @notice Tracks total number of claimants who have claimed from a forfeited puzzle
+    mapping(uint256 => uint256) public forfeitClaimantCount;
+
     /// @dev Reserved storage gap for future upgrades (UUPS pattern)
-    uint256[50] private __gap;
+    uint256[48] private __gap;
 
     /// @notice Disables initializers to prevent implementation contract from being initialized
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -283,9 +289,23 @@ contract GuessGame is IGuessGame, Initializable, UUPSUpgradeable, OwnableUpgrade
 
         // Mark as claimed
         guesserClaimed[puzzleId][msg.sender] = true;
+        forfeitClaimantCount[puzzleId]++;
 
         // Calculate payout: stake + proportional share of bounty
-        uint256 bountyShare = (puzzle.bounty * myChallenges) / puzzle.pendingAtForfeit;
+        // If this is the last claimant, give them the remaining bounty to prevent rounding dust
+        uint256 bountyShare;
+        if (forfeitClaimantCount[puzzleId] == puzzle.pendingAtForfeit) {
+            // Error safety: if somehow claimed more than total bounty, fall back to 0
+            if (puzzle.bounty > bountyClaimedTotal[puzzleId]) {
+                bountyShare = puzzle.bounty - bountyClaimedTotal[puzzleId];
+            } else {
+                bountyShare = 0;
+            }
+        } else {
+            bountyShare = (puzzle.bounty * myChallenges) / puzzle.pendingAtForfeit;
+        }
+
+        bountyClaimedTotal[puzzleId] += bountyShare;
         uint256 totalPayout = myStake + bountyShare;
 
         // Credit to internal balance


### PR DESCRIPTION
## Problem Summary
When a puzzle is forfeited, the bounty is distributed proportionally among pending challengers using integer division:
`uint256 bountyShare = (puzzle.bounty * myChallenges) / puzzle.pendingAtForfeit;`
If the bounty is not perfectly divisible by the number of challenges, a small amount of "dust" (up to `pendingAtForfeit - 1` wei) remains stuck in the contract.

## Solution Approach
Modified `claimFromForfeited` to:
- Track the number of claimants per puzzle (`forfeitClaimantCount`).
- Track the total bounty already claimed (`bountyClaimedTotal`).
- For the last claimant, instead of the proportional share, they receive the entire remaining bounty (`puzzle.bounty - bountyClaimedTotal`).
- Reduced storage gap to maintain storage layout consistency.

## Test Evidence
Manual logic verification:
Bounty = 100, Challengers = 3.
- Claimant 1: share = (100 * 1) / 3 = 33. Total claimed = 33.
- Claimant 2: share = (100 * 1) / 3 = 33. Total claimed = 66.
- Claimant 3 (last): share = 100 - 66 = 34. Total claimed = 100.
Result: 0 dust remains.