### PR TITLE
fix: address PR #38 followup review (pool skip, URL redaction, --balance-block, remote regex, npm ci)

### DIFF
--- a/script/rewards/RUNBOOK.md
+++ b/script/rewards/RUNBOOK.md
@@ -24,7 +24,7 @@ Confirm GitHub Pages is enabled on `main` / root for `chainhackers/zk-guess-rewa
 Install deps once (npm is canonical — CI uses `npm ci` and `package-lock.json` is the committed lockfile):
 
 ```bash
-npm install
+npm ci
 ```
 
 ## Per-epoch loop
@@ -38,9 +38,11 @@ source .env  # exports BASE_RPC_URL
 bun run scripts/rewards/compute-epoch.ts --epoch 1
 ```
 
-Default window ends at last Monday 00:00 UTC (strict weekly cadence). Override with `--window-end <ISO>` for catch-up or historical epochs. The script writes `/tmp/epoch-<N>.csv` and logs per-category breakdown to stderr. It exits non-zero if the contract balance is `0` or no category has eligible recipients — in that case, skip this epoch, no publish needed.
+Default window ends at last Monday 00:00 UTC (strict weekly cadence). Override with `--window-end <ISO>` for catch-up or historical epochs. The script writes `/tmp/epoch-<N>.csv` and logs per-category breakdown to stderr. It exits non-zero if the pool is below the spec's 0.01 ETH skip threshold or no category has eligible recipients — in either case skip this epoch, no publish needed.
 
-Optional overrides: `--rewards-addr`, `--rpc-url`, `--indexer-url`, `--out <path>`, `--dry-run` (stdout).
+By default the pool is sized off `eth_getBalance(...,"latest")`, which can drift from the spec ("at epoch close") if claims/funding land between `windowEnd` and run time. For a spec-exact pool, pass `--balance-block <N>` with a block at or just after `windowEnd`. The chosen block tag is logged to stderr.
+
+Optional overrides: `--rewards-addr`, `--rpc-url`, `--indexer-url`, `--out <path>`, `--dry-run` (stdout), `--balance-block <tag>`.
 
 For hand-crafted CSVs (e.g., one-off test payouts), skip this step and write the CSV directly:
 
@@ -130,7 +132,7 @@ Open <https://zk-guess.chainhackers.xyz/rewards> with the recipient wallet conne
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `compute-epoch.ts` errors `pool is zero` | Rewards contract balance is `0` | Seed the contract via `cast send --value ... --account deployer`, or skip the epoch |
+| `compute-epoch.ts` errors `pool ... is below minimum ... (0.01 ETH)` | Rewards contract balance / 2 < 0.01 ETH | Seed the contract via `cast send --value ... --account deployer`, or skip the epoch — the pool rolls forward |
 | `compute-epoch.ts` errors `no eligible recipients across all categories` | Window had no qualifying activity | Skip the epoch; the pool rolls forward. Retry next Monday. |
 | Builder errors `--out … does not have chainhackers/zk-guess-rewards as a remote` | Pointed `--out` at the wrong dir | Pass the correct path or omit (defaults to `../zk-guess-rewards`) |
 | Builder errors `epoch directory already exists` | Re-running on the same epoch number | `rm -rf ../zk-guess-rewards/<N>/`, then re-run |

--- a/scripts/rewards/build-epoch.ts
+++ b/scripts/rewards/build-epoch.ts
@@ -106,7 +106,12 @@ function assertOutIsRewardsRepo(outDir: string) {
   } catch {
     die(`--out ${outDir} is not a git repo. Clone ${REWARDS_REMOTE} first.`);
   }
-  if (!remotes.includes(REWARDS_REMOTE)) {
+  // Match the exact org/repo path on a remote URL boundary so siblings like
+  // "zk-guess-rewards-backup" are rejected. The path must be preceded by ":" or "/"
+  // (URL boundary) and followed by optional ".git" then whitespace/EOL (end of URL token).
+  const escaped = REWARDS_REMOTE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`[:/]${escaped}(\\.git)?(?=\\s|$)`);
+  if (!re.test(remotes)) {
     die(`--out ${outDir} does not have ${REWARDS_REMOTE} as a remote. Refusing to write.`);
   }
 }

--- a/scripts/rewards/compute-epoch.ts
+++ b/scripts/rewards/compute-epoch.ts
@@ -8,6 +8,9 @@
  * Options:
  *   --epoch <N>            epoch number (required)
  *   --window-end <iso>     7-day window end; default = last Monday 00:00 UTC
+ *   --balance-block <tag>  block tag for Rewards balance lookup ("latest", decimal, or 0x-hex);
+ *                          default "latest". Pass the block at/after windowEnd for spec-conformant
+ *                          pool sizing; default drifts with claims/funding between windowEnd and run.
  *   --rewards-addr <addr>  defaults to Base mainnet 0x3f40...8c1c
  *   --rpc-url <url>        defaults to $BASE_RPC_URL or $BASE_MAINNET_RPC
  *   --indexer-url <url>    defaults to production HyperIndex GraphQL endpoint
@@ -16,6 +19,7 @@
  *
  * Rules (spec 2026-04-18, §v1):
  *   - Pool = floor(balance/2). Other half rolls forward.
+ *   - Skip threshold: if pool < 0.01 ETH, exit non-zero — no root for this epoch.
  *   - 30% active guesser streak: ≥1 Challenge each of 7 window days AND ≥3 total → equal split
  *   - 20% active creator streak: created ≥1 puzzle in window AND 0 forfeited → equal split
  *   - 25% top 3 puzzle creators by Puzzle count in window → 50/30/20
@@ -28,6 +32,7 @@ import { writeFileSync } from "node:fs";
 const DEFAULT_REWARDS_ADDR = "0x3f403b992a4b0a2a8820e8818cac17e6f7cd8c1c";
 const DEFAULT_INDEXER_URL = "https://indexer.hyperindex.xyz/aa21ad1/v1/graphql";
 const WINDOW_SECONDS = 7 * 24 * 60 * 60;
+const MIN_POOL_WEI = 10n ** 16n; // 0.01 ETH; matches spec skip threshold
 const TOP3_WEIGHTS = [50n, 30n, 20n] as const;
 
 interface Challenge {
@@ -47,6 +52,7 @@ interface Puzzle {
 type Args = {
   epoch: number;
   windowEnd: number;
+  balanceBlock: string; // "latest" or hex/decimal block number tag (e.g. "0x1a2b" or "12345")
   rewardsAddr: string;
   rpcUrl: string;
   indexerUrl: string;
@@ -66,9 +72,17 @@ function lastMondayUtcEpochSeconds(now = new Date()): number {
   return Math.floor(midnight / 1000) - daysBack * 86400;
 }
 
+function normalizeBalanceBlock(raw: string): string {
+  if (raw === "latest") return "latest";
+  if (/^0x[0-9a-fA-F]+$/.test(raw)) return raw.toLowerCase();
+  if (/^[0-9]+$/.test(raw)) return "0x" + BigInt(raw).toString(16);
+  die(`invalid --balance-block: ${raw} (expected "latest", decimal, or 0x-hex)`);
+}
+
 function parseArgs(argv: string[]): Args {
   let epoch: number | undefined;
   let windowEndIso: string | undefined;
+  let balanceBlockRaw: string | undefined;
   let rewardsAddr = DEFAULT_REWARDS_ADDR;
   let rpcUrl = process.env.BASE_RPC_URL || process.env.BASE_MAINNET_RPC || "";
   let indexerUrl = DEFAULT_INDEXER_URL;
@@ -84,6 +98,7 @@ function parseArgs(argv: string[]): Args {
     };
     if (a === "--epoch") epoch = Number(next());
     else if (a === "--window-end") windowEndIso = next();
+    else if (a === "--balance-block") balanceBlockRaw = next();
     else if (a === "--rewards-addr") rewardsAddr = next();
     else if (a === "--rpc-url") rpcUrl = next();
     else if (a === "--indexer-url") indexerUrl = next();
@@ -104,9 +119,12 @@ function parseArgs(argv: string[]): Args {
       : Math.floor(new Date(windowEndIso).getTime() / 1000);
   if (!Number.isFinite(windowEnd) || windowEnd <= 0) die(`invalid --window-end: ${windowEndIso}`);
 
+  const balanceBlock = balanceBlockRaw === undefined ? "latest" : normalizeBalanceBlock(balanceBlockRaw);
+
   return {
     epoch,
     windowEnd,
+    balanceBlock,
     rewardsAddr,
     rpcUrl,
     indexerUrl,
@@ -115,11 +133,11 @@ function parseArgs(argv: string[]): Args {
   };
 }
 
-async function fetchBalanceWei(rpcUrl: string, addr: string): Promise<bigint> {
+async function fetchBalanceWei(rpcUrl: string, addr: string, blockTag: string): Promise<bigint> {
   const res = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getBalance", params: [addr, "latest"] }),
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getBalance", params: [addr, blockTag] }),
   });
   if (!res.ok) die(`RPC error ${res.status}: ${await res.text()}`);
   const json = (await res.json()) as { result?: string; error?: { message: string } };
@@ -142,7 +160,7 @@ async function gql<T>(url: string, query: string, variables: Record<string, unkn
 }
 
 async function fetchChallenges(url: string, start: number, end: number): Promise<Challenge[]> {
-  // Hasura pagination: page through by timestamp+id (stable lexical order).
+  // Hasura pagination: page through results with limit/offset, ordered by timestamp+id for stability.
   const pageSize = 1000;
   const all: Challenge[] = [];
   let offset = 0;
@@ -256,17 +274,41 @@ function formatDate(sec: number): string {
   return new Date(sec * 1000).toISOString();
 }
 
+function redactUrlForLog(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    url.search = "";
+    url.hash = "";
+    if (url.username) url.username = "***";
+    if (url.password) url.password = "***";
+    if (url.pathname && url.pathname !== "/") {
+      const parts = url.pathname.split("/");
+      const lastIndex = parts.length - 1;
+      if (parts[lastIndex] !== "") {
+        parts[lastIndex] = "***";
+      } else if (lastIndex > 0) {
+        parts[lastIndex - 1] = "***";
+      }
+      url.pathname = parts.join("/");
+    }
+    return url.toString();
+  } catch {
+    return "[redacted]";
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const windowStart = args.windowEnd - WINDOW_SECONDS;
 
   console.error(`Epoch ${args.epoch} window: [${formatDate(windowStart)}, ${formatDate(args.windowEnd)})`);
   console.error(`Rewards: ${args.rewardsAddr}`);
-  console.error(`RPC:     ${args.rpcUrl.replace(/\/[^/]+$/, "/***")}`);
-  console.error(`Indexer: ${args.indexerUrl}`);
+  console.error(`RPC:     ${redactUrlForLog(args.rpcUrl)}`);
+  console.error(`Indexer: ${redactUrlForLog(args.indexerUrl)}`);
+  console.error(`Balance block: ${args.balanceBlock}${args.balanceBlock === "latest" ? " (run-time, not epoch close)" : ""}`);
 
   const [balance, challenges, puzzles] = await Promise.all([
-    fetchBalanceWei(args.rpcUrl, args.rewardsAddr),
+    fetchBalanceWei(args.rpcUrl, args.rewardsAddr, args.balanceBlock),
     fetchChallenges(args.indexerUrl, windowStart, args.windowEnd),
     fetchPuzzles(args.indexerUrl, windowStart, args.windowEnd),
   ]);
@@ -275,7 +317,9 @@ async function main() {
   console.error(`Window activity: ${challenges.length} challenges, ${puzzles.length} puzzles`);
 
   const pool = balance / 2n;
-  if (pool === 0n) die("pool is zero (contract balance = 0); nothing to distribute");
+  if (pool < MIN_POOL_WEI) {
+    die(`pool ${pool} wei is below minimum ${MIN_POOL_WEI} wei (0.01 ETH); skip this epoch per spec`);
+  }
 
   const guesserStreakPool = (pool * 30n) / 100n;
   const creatorStreakPool = (pool * 20n) / 100n;


### PR DESCRIPTION
Followup to merged PR #38. Addresses six post-merge Copilot review comments.

## Changes

- **`compute-epoch.ts`** — enforce spec's 0.01 ETH pool skip threshold (was: only skipped on `0`). The spec at `docs/superpowers/specs/2026-04-18-forfeit-rewards-merkle-distribution-design.md:188` reads: *"Skip threshold: If pool < 0.01 ETH, skip the epoch (no root published)."* The previous behaviour could distribute tiny payouts contrary to the spec.
- **`compute-epoch.ts`** — URL-parser based redaction. The previous `replace(/\/[^/]+$/, "/***")` only redacted the final path segment, so RPC URLs with query-string API keys (e.g. `?apiKey=…`) still printed the key. New `redactUrlForLog` clears search/hash/credentials and stars out the last path segment; falls back to `[redacted]` on parse failure.
- **`compute-epoch.ts`** — new `--balance-block <tag>` flag. Default is `"latest"` (stderr-logged with a note that the pool may drift between window-end and run time). Operators can pass a block at/after `windowEnd` for a spec-exact pool. Accepts `"latest"`, decimal, or `0x`-hex.
- **`compute-epoch.ts`** — pagination comment now matches the implementation (offset/limit ordered by timestamp+id), instead of incorrectly claiming cursor-based pagination.
- **`build-epoch.ts`** — `assertOutIsRewardsRepo` now matches the remote on a URL boundary (`[:/]chainhackers/zk-guess-rewards(\.git)?(?=\s|$)`). Verified inline that all four canonical forms match (SSH/HTTPS × with/without `.git`) and that `chainhackers/zk-guess-rewards-backup`, `-fork`, and `foo/zk-guess-rewards.git` are rejected. Previous `String.includes` allowed siblings through.
- **`RUNBOOK.md`** — `npm ci` instead of `npm install` (matches CI; doesn't touch the lockfile). New failure-mode row for the 0.01 ETH skip. Documents `--balance-block`.

## Tests / verification

- `forge build` and `forge fmt --check` clean.
- `bun run scripts/rewards/compute-epoch.ts --epoch 1 --dry-run` against Base mainnet exits non-zero with `pool 0 wei is below minimum 10000000000000000 wei (0.01 ETH); skip this epoch per spec` (current contract balance is 0).
- RPC redaction smoke-tested: `https://base-mainnet.g.alchemy.com/v2/<key>` → `https://base-mainnet.g.alchemy.com/v2/***`.
- Remote-regex verified across 8 cases (4 valid forms accepted, 4 sibling/foreign URLs rejected).