### PR TITLE
docs: record Blockaid verifiedProject filing + approval

### DIFF
--- a/docs/security/not-a-mixer.md
+++ b/docs/security/not-a-mixer.md
@@ -170,10 +170,11 @@ funding.
 
 ## Reputation pointers
 
+- Project homepage: https://zk-guess.chainhackers.xyz
+- Blockaid `verifiedProject` filing submitted 2026-05-07 (no public reference issued at submit time; awaiting review)
 - Farcaster mini-app listing: <!-- TODO: URL once submitted -->
 - boost.xyz campaign: <!-- TODO: URL once active -->
 - ENS pointer: `zkguess.chainhackers.eth` <!-- TODO: confirm registered -->
-- Project homepage: https://zk-guess.chainhackers.xyz
 
 ## Bug bounty / disclosure
 

--- a/docs/security/not-a-mixer.md
+++ b/docs/security/not-a-mixer.md
@@ -171,7 +171,7 @@ funding.
 ## Reputation pointers
 
 - Project homepage: https://zk-guess.chainhackers.xyz
-- Blockaid `verifiedProject` filing submitted 2026-05-07 (no public reference issued at submit time; awaiting review)
+- Blockaid `verifiedProject` filing: submitted 2026-05-07, approved 2026-05-08 — v2.1 contracts confirmed benign, the prior cluster flag (anchored on the v1 monolithic EOA) was modified accordingly. Up to 24h for the change to propagate to all integrations.
 - Farcaster mini-app listing: <!-- TODO: URL once submitted -->
 - boost.xyz campaign: <!-- TODO: URL once active -->
 - ENS pointer: `zkguess.chainhackers.eth` <!-- TODO: confirm registered -->


### PR DESCRIPTION
Records the Blockaid `verifiedProject` flow under reputation pointers in `docs/security/not-a-mixer.md`.

- Submitted 2026-05-07 with the v2.1 proxy address `0x6F89…66B4`.
- Approved 2026-05-08 — Blockaid confirmed v2.1 contracts are benign and the prior cluster flag (anchored on the v1 monolithic EOA `0x4c7AE6…9B7A`) was modified accordingly. Up to 24h for the change to propagate.

Closes #45.